### PR TITLE
[sc-86818]: update frontend with schemas

### DIFF
--- a/.github/workflows/update-frontend-schemas.yaml
+++ b/.github/workflows/update-frontend-schemas.yaml
@@ -1,0 +1,27 @@
+name: Update frontend schemas
+
+on:
+    push:
+        branches: [main]
+        paths: ["schemas/**"]
+    workflow_dispatch:
+
+jobs:
+    # We have to invoke via repo-dispatch to a private repo so this will not show pass/fail or results here
+    ci-trigger-notifications:
+        name: Trigger updates on private repos
+        runs-on: ubuntu-latest
+        permissions:
+          contents: none
+        steps:
+          - name: Repository Dispatch
+            uses: peter-evans/repository-dispatch@v3
+            with:
+              token: ${{ secrets.CI_PAT }}
+              repository: chronosphereio/calyptia-frontend
+              event-type: schema-update
+            #   Some extra info if required
+              client-payload: |-
+                {
+                  "github": ${{ toJson(github) }},
+                }

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Global Owners
+# -------------
+*               @chronosphereio/pipeline-eng


### PR DESCRIPTION
Triggers a schema update on the UI repo.
We have to use repo-dispatch to send public->private events and there will be no linkage to the job here but we do pass full context over if needs be.
Also added codeowners.

Needs https://github.com/chronosphereio/calyptia-frontend/pull/1374 to function correctly but can be merged prior to that as the dispatch event will just be ignored until then.