### PR TITLE
ci: fix missing Core FB errors [sc-114705]

### DIFF
--- a/scripts/create-operator-mappings.sh
+++ b/scripts/create-operator-mappings.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Used to authenticate with gh api CLI
 export GH_TOKEN=${GITHUB_TOKEN:?}
 OPERATOR_REPO=${OPERATOR_REPO:-chronosphereio/calyptia-core-operator-releases}
+BACKEND_REPO=${BACKEND_REPO:-chronosphereio/calyptia-backend}
 SCHEMA_FILENAME=${SCHEMA_FILENAME:-$SCRIPT_DIR/../operator/core-fluent-bit-default-versions.json}
 
 TAGS=$(gh api \
@@ -17,29 +18,55 @@ echo '{' > "$SCHEMA_FILENAME"
 
 for TAG in $TAGS; do
   echo "Operator release: $TAG"
+
+  CORE_FLUENT_BIT_VERSION=""
     # mkdir -p "${SCHEMA_DIR}/${TAG}"
     # Grab the manifest for each release
   MANIFEST_URL=$(gh api \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     /repos/"${OPERATOR_REPO}"/releases/tags/"${TAG}" --jq '.assets[]|select(.name == "manifest.yaml")|.browser_download_url')
-  echo "manifest.yaml: $MANIFEST_URL"
+  if [[ -z "$MANIFEST_URL" ]]; then
+    echo No manifest found so attempting to retrieve value from release info
+    CORE_FB_IMAGE=$(gh release view "$TAG" --repo "$BACKEND_REPO" | grep 'ghcr.io/calyptia/core/calyptia-fluent-bit')
+    CORE_FLUENT_BIT_VERSION="ghcr.io/calyptia/core/calyptia-fluent-bit:${CORE_FB_IMAGE##*ghcr.io/calyptia/core/calyptia-fluent-bit:}"
+  else
+    echo "manifest.yaml: $MANIFEST_URL"
 
-  # Select the CRD for pipelines then extract the image field from that
-  CORE_FLUENT_BIT_VERSION=$(curl -sSfL "$MANIFEST_URL" | yq 'select(.kind == "CustomResourceDefinition")| select(.metadata.name == "pipelines.core.calyptia.com")|.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.image.default')
-
-  echo "$TAG : $CORE_FLUENT_BIT_VERSION"
-  echo "\"$TAG\": \"$CORE_FLUENT_BIT_VERSION\"," >> "$SCHEMA_FILENAME"
+    # Select the CRD for pipelines then extract the image field from that
+    CORE_FLUENT_BIT_VERSION=$(curl -sSfL "$MANIFEST_URL" | yq 'select(.kind == "CustomResourceDefinition")| select(.metadata.name == "pipelines.core.calyptia.com")|.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.image.default')
+  fi
+  if [[ -n "$CORE_FLUENT_BIT_VERSION" ]]; then
+    echo "$TAG : $CORE_FLUENT_BIT_VERSION"
+    echo "\"$TAG\": \"$CORE_FLUENT_BIT_VERSION\"," >> "$SCHEMA_FILENAME"
+  else
+    echo "ERROR: unable to retrieve Core FB version for $TAG"
+    exit 1
+  fi
 done
 
-# Add latest at end to close off the object fields - no need to cope with commas not at end of last entry then
 MANIFEST_URL=$(gh api \
   -H "Accept: application/vnd.github+json" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   /repos/"${OPERATOR_REPO}"/releases/latest --jq '.assets[]|select(.name == "manifest.yaml")|.browser_download_url')
-echo "manifest.yaml: $MANIFEST_URL"
 
-CORE_FLUENT_BIT_VERSION=$(curl -sSfL "$MANIFEST_URL" | yq 'select(.kind == "CustomResourceDefinition")| select(.metadata.name == "pipelines.core.calyptia.com")|.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.image.default')
-echo "\"latest\": \"$CORE_FLUENT_BIT_VERSION\"" >> "$SCHEMA_FILENAME"
+CORE_FLUENT_BIT_VERSION=""
+if [[ -z "$MANIFEST_URL" ]]; then
+  echo No manifest found so attempting to retrieve value from release info
+  CORE_FB_IMAGE=$(gh release view "$(gh release list --json name,isLatest --jq '.[] | select(.isLatest)|.name' --repo "$OPERATOR_REPO")" --repo "$BACKEND_REPO" | grep 'ghcr.io/calyptia/core/calyptia-fluent-bit')
+  CORE_FLUENT_BIT_VERSION="ghcr.io/calyptia/core/calyptia-fluent-bit:${CORE_FB_IMAGE##*ghcr.io/calyptia/core/calyptia-fluent-bit:}"
+else
+  echo "manifest.yaml: $MANIFEST_URL"
+
+  # Select the CRD for pipelines then extract the image field from that
+  CORE_FLUENT_BIT_VERSION=$(curl -sSfL "$MANIFEST_URL" | yq 'select(.kind == "CustomResourceDefinition")| select(.metadata.name == "pipelines.core.calyptia.com")|.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.image.default')
+fi
+if [[ -n "$CORE_FLUENT_BIT_VERSION" ]]; then
+  echo "$TAG : $CORE_FLUENT_BIT_VERSION"
+  echo "\"latest\": \"$CORE_FLUENT_BIT_VERSION\"" >> "$SCHEMA_FILENAME"
+else
+  echo "ERROR: unable to retrieve Core FB version for $TAG"
+  exit 1
+fi
 
 echo '}' >> "$SCHEMA_FILENAME"


### PR DESCRIPTION
Resolves failures seen due to missing `manifest.yaml` file, e.g. https://github.com/chronosphereio/calyptia-core-index/pull/363/commits/f1edd4ef512c44c982a600f271675756f366b312

We fall back to pulling info from the backend release body.

Tested by running locally to confirm no updates to latest versions released.