### PR TITLE
chore: Specify golangci-lint version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,3 +40,4 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2
         with:
           workdir: go-index
+          golangci_lint_version: v1.64.8


### PR DESCRIPTION
golangci-lint released a v2 recently which changes how the configuration
is specified.

We don't want to pick up new breaking changes implicitly, so specify
the latest 1.x version of golangci-lint, which we can update separately.