### PR TITLE
fix: overwrite only the numbered embedded schema file [sc-135865].

### DIFF
--- a/scripts/copy-schemas-to-go-fluentbit-config.sh
+++ b/scripts/copy-schemas-to-go-fluentbit-config.sh
@@ -27,4 +27,4 @@ pushd "$OUTPUT_DIR/schemas/"
 popd
 
 # Update the embedded schema in Go code
-sed -i -E "s|//go:embed schemas/.*\.json|//go:embed schemas/$latest_version.json|g" "$OUTPUT_DIR/schema.go"
+sed -i -E "s|//go:embed schemas/[0-9]+\.[0-9]+\.[0-9]+\.json|//go:embed schemas/$latest_version.json|g" "$OUTPUT_DIR/schema.go"


### PR DESCRIPTION
Only update the schema embed directive for the versioned file, otherwise the other schema files will not be included.

This is tangentially related to [sc-135865].